### PR TITLE
Fixed issue with triggering next() function when component receives empty dataLength

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "elementsui-react",
-	"version": "0.4.4",
+	"version": "0.4.5",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "elementsui-react",
-	"version": "0.4.4",
+	"version": "0.4.5",
 	"main": "./lib/index.js",
 	"private": true,
 	"engines": {

--- a/src/components/Content/InfiniteList/InfiniteList.js
+++ b/src/components/Content/InfiniteList/InfiniteList.js
@@ -167,7 +167,7 @@ export default class InfiniteList extends React.Component {
 
 		let atBottom = this.isElementAtBottom(target);
 
-		if (atBottom && this.props.hasMore) {
+		if (atBottom && this.props.hasMore && this.props.dataLength) {
 			this.setState((ps) => ({ ...ps, actionTriggered: true, showLoader: true }));
 			this.props.next();
 		}


### PR DESCRIPTION
Problem occurs after infinite list has loaded a couple of pages and then receives empty dataLength property (usually it happens when DataSource has been changed and we need to reload list)