### PR TITLE
Fixed time only mode of DateTimePicker 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "elementsui-react",
-	"version": "0.5.13",
+	"version": "0.5.14",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "elementsui-react",
-	"version": "0.5.13",
+	"version": "0.5.14",
 	"main": "./lib/index.js",
 	"private": true,
 	"engines": {

--- a/src/components/Pickers/DateTimePicker/DateTimePicker.js
+++ b/src/components/Pickers/DateTimePicker/DateTimePicker.js
@@ -34,6 +34,10 @@ class DateTimePicker extends React.Component {
 			this.dateFormatId = this.currentNls[`longDateFormat_${dateFormat}`];
 		}
 
+		if (this.showTimeSelectOnly) {
+			return;
+		}
+
 		if (timeFormat === undefined) {
 			this.timeFormatId = this.currentNls["time"];
 		} else if (typeof timeFormat === "string") {


### PR DESCRIPTION
We don't need to set a TimeFormat when we want to show time only