### PR TITLE
F pak 143836 lookup enter key accessibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "elementsui-react",
-	"version": "0.5.16",
+	"version": "0.5.17",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "elementsui-react",
-	"version": "0.5.16",
+	"version": "0.5.17",
 	"main": "./lib/index.js",
 	"private": true,
 	"engines": {

--- a/src/components/Pickers/Lookup/Lookup.js
+++ b/src/components/Pickers/Lookup/Lookup.js
@@ -521,6 +521,9 @@ class Lookup extends React.PureComponent {
 		const eventKey = e.key;
 		switch (eventKey) {
 			case "Enter":
+				if (!this.state.menuIsOpen) {
+					e.preventDefault();
+				}
 				return this.onMultiValueLabelClick()(e);
 			case "ArrowLeft":
 			case "ArrowRight":


### PR DESCRIPTION
Previously 'elementsForm' using <HotKeys> component handled all 'Enter' keys events. That led to the situations with lookup accessibility (wasn't possible to select an available option by pressing 'Enter'). After my fix elementsForm will not do 'preventDefault' for lookups and some other components(select, button etc) and that will allow to user to select a lookup option using 'Enter' key. But here is also another side of this changes comes - if to press 'Enter' on a lookup with collapsed menu, form still will be submitted by this action and we don't want this. To handle this I added call of preventDefault for every enter key event if 'menuIsOpen' property set to false. It fixed situations and doesn't break any other cases (when lookup has a popup or it's multiple select lookup)